### PR TITLE
Enhancement/waveform customizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.1+4
+
+* Added customization options `isRoundedRectangle` and `isCentered` to RectangleWaveform. Setting `isRoundedRectangle` to true draws rounded rectangles instead of regular ones. Setting `isCentered` to true would align each rectangle in the center along Y axis with respect to it's center along it's height. `isCentered` won't have any effect if `absolute` is set to true.
 ## 1.1.1+4
 
 * Updates in Api for declaring waveforms. `maxDuration` and `elapsedDuration` are now made optional when you're declaring a waveform. Avoids having to provide them when not needed like in case when you need a static waveform without any active waveform track.

--- a/example/lib/waveforms_dashboard.dart
+++ b/example/lib/waveforms_dashboard.dart
@@ -675,6 +675,22 @@ class _WaveformsDashboardState extends State<WaveformsDashboard> {
                           ),
                         ],
                       ),
+                      sizedBox,
+                      Column(
+                        children: [
+                          const Text("isCentered",
+                              style: TextStyle(color: Colors.white)),
+                          Switch(
+                            inactiveTrackColor: Colors.grey[300],
+                            value: waveformCustomizations.isCentered,
+                            onChanged: (value) {
+                              setState(() {
+                                waveformCustomizations.isCentered = value;
+                              });
+                            },
+                          ),
+                        ],
+                      ),
                     ],
                   )
                 else
@@ -796,6 +812,7 @@ class RectangleWaveformExample extends StatelessWidget {
       activeBorderColor: waveformCustomizations.activeBorderColor,
       inactiveBorderColor: waveformCustomizations.inactiveBorderColor,
       isRoundedRectangle: waveformCustomizations.isRoundedRectangle,
+      isCentered: waveformCustomizations.isCentered,
     );
   }
 }
@@ -857,6 +874,7 @@ class WaveformCustomizations {
     this.activeBorderColor = Colors.white,
     this.inactiveBorderColor = Colors.white,
     this.isRoundedRectangle = false,
+    this.isCentered = false,
   });
 
   double height;
@@ -873,4 +891,5 @@ class WaveformCustomizations {
   Color activeBorderColor;
   Color inactiveBorderColor;
   bool isRoundedRectangle;
+  bool isCentered;
 }

--- a/example/lib/waveforms_dashboard.dart
+++ b/example/lib/waveforms_dashboard.dart
@@ -658,6 +658,23 @@ class _WaveformsDashboardState extends State<WaveformsDashboard> {
                           Icons.color_lens,
                         ),
                       ),
+                      sizedBox,
+                      Column(
+                        children: [
+                          const Text("isRounedRectangle",
+                              style: TextStyle(color: Colors.white)),
+                          Switch(
+                            inactiveTrackColor: Colors.grey[300],
+                            value: waveformCustomizations.isRoundedRectangle,
+                            onChanged: (value) {
+                              setState(() {
+                                waveformCustomizations.isRoundedRectangle =
+                                    value;
+                              });
+                            },
+                          ),
+                        ],
+                      ),
                     ],
                   )
                 else
@@ -778,6 +795,7 @@ class RectangleWaveformExample extends StatelessWidget {
       borderWidth: waveformCustomizations.borderWidth,
       activeBorderColor: waveformCustomizations.activeBorderColor,
       inactiveBorderColor: waveformCustomizations.inactiveBorderColor,
+      isRoundedRectangle: waveformCustomizations.isRoundedRectangle,
     );
   }
 }
@@ -838,6 +856,7 @@ class WaveformCustomizations {
     this.borderWidth = 1.0,
     this.activeBorderColor = Colors.white,
     this.inactiveBorderColor = Colors.white,
+    this.isRoundedRectangle = false,
   });
 
   double height;
@@ -853,4 +872,5 @@ class WaveformCustomizations {
   double borderWidth;
   Color activeBorderColor;
   Color inactiveBorderColor;
+  bool isRoundedRectangle;
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -96,7 +96,7 @@ packages:
       path: "/Users/rutviktak/flutter_projects/flutter_plugins/flutter_audio_visualizer/"
       relative: false
     source: path
-    version: "1.1.1+4"
+    version: "1.2.1+4"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/src/core/waveform_painters_ab.dart
+++ b/lib/src/core/waveform_painters_ab.dart
@@ -76,9 +76,8 @@ abstract class ActiveWaveformPainter extends WaveformPainter {
   /// Stroke/Border Width
   final Color borderColor;
 
-  /// Whether the waveform should be rePainted or not.
-  @override
-  bool shouldRepaint(covariant ActiveWaveformPainter oldDelegate) {
+  /// Get shoudlRepaintValue
+  bool getShouldRepaintValue(covariant ActiveWaveformPainter oldDelegate) {
     return !checkforSamplesEquality(activeSamples, oldDelegate.activeSamples) ||
         color != oldDelegate.color ||
         gradient != oldDelegate.gradient ||
@@ -87,6 +86,12 @@ abstract class ActiveWaveformPainter extends WaveformPainter {
         style != oldDelegate.style ||
         borderWidth != oldDelegate.borderWidth ||
         borderColor != oldDelegate.borderColor;
+  }
+
+  /// Whether the waveform should be rePainted or not.
+  @override
+  bool shouldRepaint(covariant ActiveWaveformPainter oldDelegate) {
+    return getShouldRepaintValue(oldDelegate);
   }
 }
 
@@ -119,9 +124,8 @@ abstract class InActiveWaveformPainter extends WaveformPainter {
   /// Stroke/Border Width
   final Color borderColor;
 
-  /// Whether the waveform should be rePainted or not.
-  @override
-  bool shouldRepaint(covariant InActiveWaveformPainter oldDelegate) {
+  /// Get shoudlRepaintValue
+  bool getShouldRepaintValue(covariant InActiveWaveformPainter oldDelegate) {
     return !checkforSamplesEquality(samples, oldDelegate.samples) ||
         color != oldDelegate.color ||
         gradient != oldDelegate.gradient ||
@@ -130,6 +134,12 @@ abstract class InActiveWaveformPainter extends WaveformPainter {
         style != oldDelegate.style ||
         borderWidth != oldDelegate.borderWidth ||
         borderColor != oldDelegate.borderColor;
+  }
+
+  /// Whether the waveform should be rePainted or not.
+  @override
+  bool shouldRepaint(covariant InActiveWaveformPainter oldDelegate) {
+    return getShouldRepaintValue(oldDelegate);
   }
 }
 
@@ -168,9 +178,10 @@ abstract class ActiveInActiveWaveformPainter extends WaveformPainter {
   /// Stroke Width
   final double strokeWidth;
 
-  /// Whether the waveform should be rePainted or not.
-  @override
-  bool shouldRepaint(covariant ActiveInActiveWaveformPainter oldDelegate) {
+  /// Get shoudlRepaintValue
+  bool getShouldRepaintValue(
+    covariant ActiveInActiveWaveformPainter oldDelegate,
+  ) {
     return activeRatio != oldDelegate.activeRatio ||
         activeColor != oldDelegate.activeColor ||
         inactiveColor != oldDelegate.inactiveColor ||
@@ -181,5 +192,11 @@ abstract class ActiveInActiveWaveformPainter extends WaveformPainter {
         sampleWidth != oldDelegate.sampleWidth ||
         strokeWidth != oldDelegate.strokeWidth ||
         style != oldDelegate.style;
+  }
+
+  /// Whether the waveform should be rePainted or not.
+  @override
+  bool shouldRepaint(covariant ActiveInActiveWaveformPainter oldDelegate) {
+    return getShouldRepaintValue(oldDelegate);
   }
 }

--- a/lib/src/waveforms/curved_polygon_waveform/curved_polygon_waveform.dart
+++ b/lib/src/waveforms/curved_polygon_waveform/curved_polygon_waveform.dart
@@ -74,20 +74,18 @@ class _SquigglyWaveformState extends AudioWaveformState<CurvedPolygonWaveform> {
     final activeRatio = this.activeRatio;
     final waveformAlignment = this.waveformAlignment;
 
-    return RepaintBoundary(
-      child: CustomPaint(
-        size: Size(widget.width, widget.height),
-        isComplex: true,
-        painter: CurvedPolygonActiveInActiveWaveformPainter(
-          samples: processedSamples,
-          activeColor: widget.activeColor,
-          inactiveColor: widget.inactiveColor,
-          activeRatio: activeRatio,
-          waveformAlignment: waveformAlignment,
-          strokeWidth: widget.strokeWidth,
-          sampleWidth: sampleWidth,
-          style: widget.style,
-        ),
+    return CustomPaint(
+      size: Size(widget.width, widget.height),
+      isComplex: true,
+      painter: CurvedPolygonActiveInActiveWaveformPainter(
+        samples: processedSamples,
+        activeColor: widget.activeColor,
+        inactiveColor: widget.inactiveColor,
+        activeRatio: activeRatio,
+        waveformAlignment: waveformAlignment,
+        strokeWidth: widget.strokeWidth,
+        sampleWidth: sampleWidth,
+        style: widget.style,
       ),
     );
   }

--- a/lib/src/waveforms/polygon_waveform/polygon_waveform.dart
+++ b/lib/src/waveforms/polygon_waveform/polygon_waveform.dart
@@ -96,18 +96,16 @@ class _PolygonWaveformState extends AudioWaveformState<PolygonWaveform> {
           ),
         ),
         if (showActiveWaveform)
-          RepaintBoundary(
-            child: CustomPaint(
-              isComplex: true,
-              size: Size(widget.width, widget.height),
-              painter: PolygonActiveWaveformPainter(
-                style: widget.style,
-                color: widget.activeColor,
-                activeSamples: activeSamples,
-                gradient: widget.activeGradient,
-                waveformAlignment: waveformAlignment,
-                sampleWidth: sampleWidth,
-              ),
+          CustomPaint(
+            isComplex: true,
+            size: Size(widget.width, widget.height),
+            painter: PolygonActiveWaveformPainter(
+              style: widget.style,
+              color: widget.activeColor,
+              activeSamples: activeSamples,
+              gradient: widget.activeGradient,
+              waveformAlignment: waveformAlignment,
+              sampleWidth: sampleWidth,
             ),
           ),
       ],

--- a/lib/src/waveforms/rectangle_waveform/active_waveform_painter.dart
+++ b/lib/src/waveforms/rectangle_waveform/active_waveform_painter.dart
@@ -99,7 +99,7 @@ class RectangleActiveWaveformPainter extends ActiveWaveformPainter {
           ..drawRRect(
             RRect.fromRectAndRadius(
               Rect.fromLTWH(x, alignPosition - y, sampleWidth, y * 2),
-              const Radius.circular(100),
+              Radius.circular(x),
             ),
             paint,
           )
@@ -107,7 +107,7 @@ class RectangleActiveWaveformPainter extends ActiveWaveformPainter {
           ..drawRRect(
             RRect.fromRectAndRadius(
               Rect.fromLTWH(x, alignPosition - y, sampleWidth, y * 2),
-              const Radius.circular(100),
+              Radius.circular(x),
             ),
             borderPaint,
           );

--- a/lib/src/waveforms/rectangle_waveform/active_waveform_painter.dart
+++ b/lib/src/waveforms/rectangle_waveform/active_waveform_painter.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'package:flutter/material.dart';
 import 'package:flutter_audio_waveforms/src/core/waveform_painters_ab.dart';
 import 'package:flutter_audio_waveforms/src/util/waveform_alignment.dart';
@@ -14,6 +16,7 @@ class RectangleActiveWaveformPainter extends ActiveWaveformPainter {
     required Color borderColor,
     required double borderWidth,
     required this.isRoundedRectangle,
+    required this.isCentered,
     Gradient? gradient,
   }) : super(
           color: color,
@@ -26,6 +29,7 @@ class RectangleActiveWaveformPainter extends ActiveWaveformPainter {
           style: PaintingStyle.fill,
         );
   final bool isRoundedRectangle;
+  final bool isCentered;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -50,6 +54,8 @@ class RectangleActiveWaveformPainter extends ActiveWaveformPainter {
         alignPosition,
         activeTrackPaint,
         borderPaint,
+        waveformAlignment,
+        isCentered,
       );
     } else {
       drawRegularRectangles(
@@ -57,48 +63,71 @@ class RectangleActiveWaveformPainter extends ActiveWaveformPainter {
         alignPosition,
         activeTrackPaint,
         borderPaint,
+        waveformAlignment,
+        isCentered,
       );
     }
   }
 
+  // ignore: long-parameter-list
   void drawRegularRectangles(
     Canvas canvas,
     double alignPosition,
     Paint paint,
     Paint borderPaint,
+    WaveformAlignment waveformAlignment,
+    bool isCentered,
   ) {
     for (var i = 0; i < activeSamples.length; i++) {
       final x = sampleWidth * i;
-      final y = activeSamples[i];
+      final isAbsolute = waveformAlignment != WaveformAlignment.center;
+      final y =
+          isCentered && !isAbsolute ? activeSamples[i] * 2 : activeSamples[i];
+      final positionFromTop =
+          isCentered && !isAbsolute ? alignPosition - y / 2 : alignPosition;
       //Draws the filled rectangles of the waveform.
       canvas
         ..drawRect(
-          Rect.fromLTWH(x, alignPosition, sampleWidth, y),
+          Rect.fromLTWH(x, positionFromTop, sampleWidth, y),
           paint,
         )
         //Draws the border for the rectangles of the waveform.
         ..drawRect(
-          Rect.fromLTWH(x, alignPosition, sampleWidth, y),
+          Rect.fromLTWH(x, positionFromTop, sampleWidth, y),
           borderPaint,
         );
     }
   }
 
+  // ignore: long-parameter-list
   void drawRoundedRectangles(
     Canvas canvas,
     double alignPosition,
     Paint paint,
     Paint borderPaint,
+    WaveformAlignment waveformAlignment,
+    bool isCentered,
   ) {
     for (var i = 0; i < activeSamples.length; i++) {
       if (i.isEven) {
         final x = sampleWidth * i;
-        final y = activeSamples[i];
+        final isAbsolute = waveformAlignment != WaveformAlignment.center;
+        final y = isAbsolute
+            ? activeSamples[i]
+            : !isCentered
+                ? activeSamples[i]
+                : activeSamples[i] * 2;
+        final positionFromTop = isAbsolute
+            ? alignPosition
+            : !isCentered
+                ? alignPosition
+                : alignPosition - y / 2;
+
         //Draws the filled rectangles of the waveform.
         canvas
           ..drawRRect(
             RRect.fromRectAndRadius(
-              Rect.fromLTWH(x, alignPosition - y, sampleWidth, y * 2),
+              Rect.fromLTWH(x, positionFromTop, sampleWidth, y),
               Radius.circular(x),
             ),
             paint,
@@ -106,7 +135,7 @@ class RectangleActiveWaveformPainter extends ActiveWaveformPainter {
           //Draws the border for the rectangles of the waveform.
           ..drawRRect(
             RRect.fromRectAndRadius(
-              Rect.fromLTWH(x, alignPosition - y, sampleWidth, y * 2),
+              Rect.fromLTWH(x, positionFromTop, sampleWidth, y),
               Radius.circular(x),
             ),
             borderPaint,
@@ -119,6 +148,7 @@ class RectangleActiveWaveformPainter extends ActiveWaveformPainter {
   bool shouldRepaint(covariant RectangleActiveWaveformPainter oldDelegate) {
     // TODO: implement shouldRepaint
     return getShouldRepaintValue(oldDelegate) ||
-        isRoundedRectangle != oldDelegate.isRoundedRectangle;
+        isRoundedRectangle != oldDelegate.isRoundedRectangle ||
+        isCentered != oldDelegate.isCentered;
   }
 }

--- a/lib/src/waveforms/rectangle_waveform/active_waveform_painter.dart
+++ b/lib/src/waveforms/rectangle_waveform/active_waveform_painter.dart
@@ -13,6 +13,7 @@ class RectangleActiveWaveformPainter extends ActiveWaveformPainter {
     required double sampleWidth,
     required Color borderColor,
     required double borderWidth,
+    required this.isRoundedRectangle,
     Gradient? gradient,
   }) : super(
           color: color,
@@ -24,6 +25,7 @@ class RectangleActiveWaveformPainter extends ActiveWaveformPainter {
           borderWidth: borderWidth,
           style: PaintingStyle.fill,
         );
+  final bool isRoundedRectangle;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -42,15 +44,37 @@ class RectangleActiveWaveformPainter extends ActiveWaveformPainter {
     //Gets the [alignPosition] depending on [waveformAlignment]
     final alignPosition = waveformAlignment.getAlignPosition(size.height);
 
+    if (isRoundedRectangle) {
+      drawRoundedRectangles(
+        canvas,
+        alignPosition,
+        activeTrackPaint,
+        borderPaint,
+      );
+    } else {
+      drawRegularRectangles(
+        canvas,
+        alignPosition,
+        activeTrackPaint,
+        borderPaint,
+      );
+    }
+  }
+
+  void drawRegularRectangles(
+    Canvas canvas,
+    double alignPosition,
+    Paint paint,
+    Paint borderPaint,
+  ) {
     for (var i = 0; i < activeSamples.length; i++) {
       final x = sampleWidth * i;
       final y = activeSamples[i];
-
       //Draws the filled rectangles of the waveform.
       canvas
         ..drawRect(
           Rect.fromLTWH(x, alignPosition, sampleWidth, y),
-          activeTrackPaint,
+          paint,
         )
         //Draws the border for the rectangles of the waveform.
         ..drawRect(
@@ -58,5 +82,43 @@ class RectangleActiveWaveformPainter extends ActiveWaveformPainter {
           borderPaint,
         );
     }
+  }
+
+  void drawRoundedRectangles(
+    Canvas canvas,
+    double alignPosition,
+    Paint paint,
+    Paint borderPaint,
+  ) {
+    for (var i = 0; i < activeSamples.length; i++) {
+      if (i.isEven) {
+        final x = sampleWidth * i;
+        final y = activeSamples[i];
+        //Draws the filled rectangles of the waveform.
+        canvas
+          ..drawRRect(
+            RRect.fromRectAndRadius(
+              Rect.fromLTWH(x, alignPosition - y, sampleWidth, y * 2),
+              const Radius.circular(100),
+            ),
+            paint,
+          )
+          //Draws the border for the rectangles of the waveform.
+          ..drawRRect(
+            RRect.fromRectAndRadius(
+              Rect.fromLTWH(x, alignPosition - y, sampleWidth, y * 2),
+              const Radius.circular(100),
+            ),
+            borderPaint,
+          );
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant RectangleActiveWaveformPainter oldDelegate) {
+    // TODO: implement shouldRepaint
+    return getShouldRepaintValue(oldDelegate) ||
+        isRoundedRectangle != oldDelegate.isRoundedRectangle;
   }
 }

--- a/lib/src/waveforms/rectangle_waveform/inactive_waveform_painter.dart
+++ b/lib/src/waveforms/rectangle_waveform/inactive_waveform_painter.dart
@@ -98,7 +98,7 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
           ..drawRRect(
             RRect.fromRectAndRadius(
               Rect.fromLTWH(x, alignPosition - y, sampleWidth, y * 2),
-              const Radius.circular(100),
+              Radius.circular(x),
             ),
             paint,
           )
@@ -106,7 +106,7 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
           ..drawRRect(
             RRect.fromRectAndRadius(
               Rect.fromLTWH(x, alignPosition - y, sampleWidth, y * 2),
-              const Radius.circular(100),
+              Radius.circular(x),
             ),
             borderPaint,
           );

--- a/lib/src/waveforms/rectangle_waveform/inactive_waveform_painter.dart
+++ b/lib/src/waveforms/rectangle_waveform/inactive_waveform_painter.dart
@@ -46,6 +46,7 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
       ..strokeWidth = borderWidth;
     //Gets the [alignPosition] depending on [waveformAlignment]
     final alignPosition = waveformAlignment.getAlignPosition(size.height);
+    final isAbsolute = waveformAlignment != WaveformAlignment.center;
 
     if (isRoundedRectangle) {
       drawRoundedRectangles(
@@ -55,6 +56,7 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
         borderPaint,
         waveformAlignment,
         isCentered,
+        isAbsolute,
       );
     } else {
       drawRegularRectangles(
@@ -64,6 +66,7 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
         borderPaint,
         waveformAlignment,
         isCentered,
+        isAbsolute,
       );
     }
   }
@@ -76,22 +79,25 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
     Paint borderPaint,
     WaveformAlignment waveformAlignment,
     bool isCentered,
+    bool isAbsolute,
   ) {
+    final isCenteredAndNotAbsolute = isCentered && !isAbsolute;
     for (var i = 0; i < samples.length; i++) {
       final x = sampleWidth * i;
-      final isAbsolute = waveformAlignment != WaveformAlignment.center;
-      final y = isCentered && !isAbsolute ? samples[i] * 2 : samples[i];
+      final y = isCenteredAndNotAbsolute ? samples[i] * 2 : samples[i];
       final positionFromTop =
-          isCentered && !isAbsolute ? alignPosition - y / 2 : alignPosition;
+          isCenteredAndNotAbsolute ? alignPosition - y / 2 : alignPosition;
+      final rectangle = Rect.fromLTWH(x, positionFromTop, sampleWidth, y);
+
       //Draws the filled rectangles of the waveform.
       canvas
         ..drawRect(
-          Rect.fromLTWH(x, positionFromTop, sampleWidth, y),
+          rectangle,
           paint,
         )
         //Draws the border for the rectangles of the waveform.
         ..drawRect(
-          Rect.fromLTWH(x, positionFromTop, sampleWidth, y),
+          rectangle,
           borderPaint,
         );
     }
@@ -105,35 +111,31 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
     Paint borderPaint,
     WaveformAlignment waveformAlignment,
     bool isCentered,
+    bool isAbsolute,
   ) {
+    final radius = Radius.circular(sampleWidth);
+    final isAbsoluteAndNotCentered = isAbsolute || !isCentered;
     for (var i = 0; i < samples.length; i++) {
       if (i.isEven) {
         final x = sampleWidth * i;
-        final isAbsolute = waveformAlignment != WaveformAlignment.center;
-        final y = isAbsolute
-            ? samples[i]
-            : !isCentered
-                ? samples[i]
-                : samples[i] * 2;
-        final positionFromTop = isAbsolute
-            ? alignPosition
-            : !isCentered
-                ? alignPosition
-                : alignPosition - y / 2;
+        final y = isAbsoluteAndNotCentered ? samples[i] : samples[i] * 2;
+        final positionFromTop =
+            isAbsoluteAndNotCentered ? alignPosition : alignPosition - y / 2;
+        final rectangle = Rect.fromLTWH(x, positionFromTop, sampleWidth, y);
         //Draws the filled rectangles of the waveform.
         canvas
           ..drawRRect(
             RRect.fromRectAndRadius(
-              Rect.fromLTWH(x, positionFromTop, sampleWidth, y),
-              Radius.circular(x),
+              rectangle,
+              radius,
             ),
             paint,
           )
           //Draws the border for the rectangles of the waveform.
           ..drawRRect(
             RRect.fromRectAndRadius(
-              Rect.fromLTWH(x, positionFromTop, sampleWidth, y),
-              Radius.circular(x),
+              rectangle,
+              radius,
             ),
             borderPaint,
           );

--- a/lib/src/waveforms/rectangle_waveform/inactive_waveform_painter.dart
+++ b/lib/src/waveforms/rectangle_waveform/inactive_waveform_painter.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'package:flutter/material.dart';
 import 'package:flutter_audio_waveforms/src/core/waveform_painters_ab.dart';
 import 'package:flutter_audio_waveforms/src/util/waveform_alignment.dart';
@@ -15,6 +17,7 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
     required Color borderColor,
     required double borderWidth,
     required this.isRoundedRectangle,
+    required this.isCentered,
   }) : super(
           samples: samples,
           color: color,
@@ -27,6 +30,7 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
         );
 
   final bool isRoundedRectangle;
+  final bool isCentered;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -49,6 +53,8 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
         alignPosition,
         paint,
         borderPaint,
+        waveformAlignment,
+        isCentered,
       );
     } else {
       drawRegularRectangles(
@@ -56,48 +62,69 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
         alignPosition,
         paint,
         borderPaint,
+        waveformAlignment,
+        isCentered,
       );
     }
   }
 
+  // ignore: long-parameter-list
   void drawRegularRectangles(
     Canvas canvas,
     double alignPosition,
     Paint paint,
     Paint borderPaint,
+    WaveformAlignment waveformAlignment,
+    bool isCentered,
   ) {
     for (var i = 0; i < samples.length; i++) {
       final x = sampleWidth * i;
-      final y = samples[i];
+      final isAbsolute = waveformAlignment != WaveformAlignment.center;
+      final y = isCentered && !isAbsolute ? samples[i] * 2 : samples[i];
+      final positionFromTop =
+          isCentered && !isAbsolute ? alignPosition - y / 2 : alignPosition;
       //Draws the filled rectangles of the waveform.
       canvas
         ..drawRect(
-          Rect.fromLTWH(x, alignPosition, sampleWidth, y),
+          Rect.fromLTWH(x, positionFromTop, sampleWidth, y),
           paint,
         )
         //Draws the border for the rectangles of the waveform.
         ..drawRect(
-          Rect.fromLTWH(x, alignPosition, sampleWidth, y),
+          Rect.fromLTWH(x, positionFromTop, sampleWidth, y),
           borderPaint,
         );
     }
   }
 
+  // ignore: long-parameter-list
   void drawRoundedRectangles(
     Canvas canvas,
     double alignPosition,
     Paint paint,
     Paint borderPaint,
+    WaveformAlignment waveformAlignment,
+    bool isCentered,
   ) {
     for (var i = 0; i < samples.length; i++) {
       if (i.isEven) {
         final x = sampleWidth * i;
-        final y = samples[i];
+        final isAbsolute = waveformAlignment != WaveformAlignment.center;
+        final y = isAbsolute
+            ? samples[i]
+            : !isCentered
+                ? samples[i]
+                : samples[i] * 2;
+        final positionFromTop = isAbsolute
+            ? alignPosition
+            : !isCentered
+                ? alignPosition
+                : alignPosition - y / 2;
         //Draws the filled rectangles of the waveform.
         canvas
           ..drawRRect(
             RRect.fromRectAndRadius(
-              Rect.fromLTWH(x, alignPosition - y, sampleWidth, y * 2),
+              Rect.fromLTWH(x, positionFromTop, sampleWidth, y),
               Radius.circular(x),
             ),
             paint,
@@ -105,7 +132,7 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
           //Draws the border for the rectangles of the waveform.
           ..drawRRect(
             RRect.fromRectAndRadius(
-              Rect.fromLTWH(x, alignPosition - y, sampleWidth, y * 2),
+              Rect.fromLTWH(x, positionFromTop, sampleWidth, y),
               Radius.circular(x),
             ),
             borderPaint,
@@ -118,6 +145,7 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
   bool shouldRepaint(covariant RectangleInActiveWaveformPainter oldDelegate) {
     // TODO: implement shouldRepaint
     return getShouldRepaintValue(oldDelegate) ||
-        isRoundedRectangle != oldDelegate.isRoundedRectangle;
+        isRoundedRectangle != oldDelegate.isRoundedRectangle ||
+        isCentered != oldDelegate.isCentered;
   }
 }

--- a/lib/src/waveforms/rectangle_waveform/inactive_waveform_painter.dart
+++ b/lib/src/waveforms/rectangle_waveform/inactive_waveform_painter.dart
@@ -14,6 +14,7 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
     required double sampleWidth,
     required Color borderColor,
     required double borderWidth,
+    required this.isRoundedRectangle,
   }) : super(
           samples: samples,
           color: color,
@@ -24,6 +25,8 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
           borderWidth: borderWidth,
           style: PaintingStyle.fill,
         );
+
+  final bool isRoundedRectangle;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -40,6 +43,29 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
     //Gets the [alignPosition] depending on [waveformAlignment]
     final alignPosition = waveformAlignment.getAlignPosition(size.height);
 
+    if (isRoundedRectangle) {
+      drawRoundedRectangles(
+        canvas,
+        alignPosition,
+        paint,
+        borderPaint,
+      );
+    } else {
+      drawRegularRectangles(
+        canvas,
+        alignPosition,
+        paint,
+        borderPaint,
+      );
+    }
+  }
+
+  void drawRegularRectangles(
+    Canvas canvas,
+    double alignPosition,
+    Paint paint,
+    Paint borderPaint,
+  ) {
     for (var i = 0; i < samples.length; i++) {
       final x = sampleWidth * i;
       final y = samples[i];
@@ -55,5 +81,43 @@ class RectangleInActiveWaveformPainter extends InActiveWaveformPainter {
           borderPaint,
         );
     }
+  }
+
+  void drawRoundedRectangles(
+    Canvas canvas,
+    double alignPosition,
+    Paint paint,
+    Paint borderPaint,
+  ) {
+    for (var i = 0; i < samples.length; i++) {
+      if (i.isEven) {
+        final x = sampleWidth * i;
+        final y = samples[i];
+        //Draws the filled rectangles of the waveform.
+        canvas
+          ..drawRRect(
+            RRect.fromRectAndRadius(
+              Rect.fromLTWH(x, alignPosition - y, sampleWidth, y * 2),
+              const Radius.circular(100),
+            ),
+            paint,
+          )
+          //Draws the border for the rectangles of the waveform.
+          ..drawRRect(
+            RRect.fromRectAndRadius(
+              Rect.fromLTWH(x, alignPosition - y, sampleWidth, y * 2),
+              const Radius.circular(100),
+            ),
+            borderPaint,
+          );
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant RectangleInActiveWaveformPainter oldDelegate) {
+    // TODO: implement shouldRepaint
+    return getShouldRepaintValue(oldDelegate) ||
+        isRoundedRectangle != oldDelegate.isRoundedRectangle;
   }
 }

--- a/lib/src/waveforms/rectangle_waveform/rectangle_waveform.dart
+++ b/lib/src/waveforms/rectangle_waveform/rectangle_waveform.dart
@@ -76,6 +76,7 @@ class RectangleWaveform extends AudioWaveform {
   /// The color of the inactive waveform border.
   final Color inactiveBorderColor;
 
+  /// If true then rounded rectangles are drawn instead of regular rectangles.
   final bool isRoundedRectangle;
 
   @override

--- a/lib/src/waveforms/rectangle_waveform/rectangle_waveform.dart
+++ b/lib/src/waveforms/rectangle_waveform/rectangle_waveform.dart
@@ -80,7 +80,10 @@ class RectangleWaveform extends AudioWaveform {
   /// If true then rounded rectangles are drawn instead of regular rectangles.
   final bool isRoundedRectangle;
 
-  /// If true then rounded rectangles are drawn instead of regular rectangles.
+  /// If true then rectangles are centered along the Y-axis with respect to
+  /// their center along their height.
+  ///
+  /// If [absolute] is true then this would've no effect.
   final bool isCentered;
 
   @override

--- a/lib/src/waveforms/rectangle_waveform/rectangle_waveform.dart
+++ b/lib/src/waveforms/rectangle_waveform/rectangle_waveform.dart
@@ -114,20 +114,18 @@ class _RectangleWaveformState extends AudioWaveformState<RectangleWaveform> {
           ),
         ),
         if (showActiveWaveform)
-          RepaintBoundary(
-            child: CustomPaint(
-              size: Size(widget.width, widget.height),
-              isComplex: true,
-              painter: RectangleActiveWaveformPainter(
-                color: widget.activeColor,
-                activeSamples: activeSamples,
-                gradient: widget.activeGradient,
-                waveformAlignment: waveformAlignment,
-                borderColor: widget.activeBorderColor,
-                borderWidth: widget.borderWidth,
-                sampleWidth: sampleWidth,
-                isRoundedRectangle: widget.isRoundedRectangle,
-              ),
+          CustomPaint(
+            size: Size(widget.width, widget.height),
+            isComplex: true,
+            painter: RectangleActiveWaveformPainter(
+              color: widget.activeColor,
+              activeSamples: activeSamples,
+              gradient: widget.activeGradient,
+              waveformAlignment: waveformAlignment,
+              borderColor: widget.activeBorderColor,
+              borderWidth: widget.borderWidth,
+              sampleWidth: sampleWidth,
+              isRoundedRectangle: widget.isRoundedRectangle,
             ),
           ),
       ],

--- a/lib/src/waveforms/rectangle_waveform/rectangle_waveform.dart
+++ b/lib/src/waveforms/rectangle_waveform/rectangle_waveform.dart
@@ -100,45 +100,42 @@ class _RectangleWaveformState extends AudioWaveformState<RectangleWaveform> {
     final waveformAlignment = this.waveformAlignment;
     final sampleWidth = this.sampleWidth;
 
-    return Container(
-      color: Colors.white38,
-      child: Stack(
-        children: [
-          RepaintBoundary(
-            child: CustomPaint(
-              size: Size(widget.width, widget.height),
-              isComplex: true,
-              painter: RectangleInActiveWaveformPainter(
-                samples: processedSamples,
-                color: widget.inactiveColor,
-                gradient: widget.inactiveGradient,
-                waveformAlignment: waveformAlignment,
-                borderColor: widget.inactiveBorderColor,
-                borderWidth: widget.borderWidth,
-                sampleWidth: sampleWidth,
-                isRoundedRectangle: widget.isRoundedRectangle,
-                isCentered: widget.isCentered,
-              ),
+    return Stack(
+      children: [
+        RepaintBoundary(
+          child: CustomPaint(
+            size: Size(widget.width, widget.height),
+            isComplex: true,
+            painter: RectangleInActiveWaveformPainter(
+              samples: processedSamples,
+              color: widget.inactiveColor,
+              gradient: widget.inactiveGradient,
+              waveformAlignment: waveformAlignment,
+              borderColor: widget.inactiveBorderColor,
+              borderWidth: widget.borderWidth,
+              sampleWidth: sampleWidth,
+              isRoundedRectangle: widget.isRoundedRectangle,
+              isCentered: widget.isCentered,
             ),
           ),
-          if (showActiveWaveform)
-            CustomPaint(
-              size: Size(widget.width, widget.height),
-              isComplex: true,
-              painter: RectangleActiveWaveformPainter(
-                color: widget.activeColor,
-                activeSamples: activeSamples,
-                gradient: widget.activeGradient,
-                waveformAlignment: waveformAlignment,
-                borderColor: widget.activeBorderColor,
-                borderWidth: widget.borderWidth,
-                sampleWidth: sampleWidth,
-                isRoundedRectangle: widget.isRoundedRectangle,
-                isCentered: widget.isCentered,
-              ),
+        ),
+        if (showActiveWaveform)
+          CustomPaint(
+            size: Size(widget.width, widget.height),
+            isComplex: true,
+            painter: RectangleActiveWaveformPainter(
+              color: widget.activeColor,
+              activeSamples: activeSamples,
+              gradient: widget.activeGradient,
+              waveformAlignment: waveformAlignment,
+              borderColor: widget.activeBorderColor,
+              borderWidth: widget.borderWidth,
+              sampleWidth: sampleWidth,
+              isRoundedRectangle: widget.isRoundedRectangle,
+              isCentered: widget.isCentered,
             ),
-        ],
-      ),
+          ),
+      ],
     );
   }
 }

--- a/lib/src/waveforms/rectangle_waveform/rectangle_waveform.dart
+++ b/lib/src/waveforms/rectangle_waveform/rectangle_waveform.dart
@@ -38,6 +38,7 @@ class RectangleWaveform extends AudioWaveform {
     bool showActiveWaveform = true,
     bool absolute = false,
     bool invert = false,
+    this.isRoundedRectangle = false,
   })  : assert(
           borderWidth >= 0 && borderWidth <= 1.0,
           'BorderWidth must be between 0 and 1',
@@ -75,6 +76,8 @@ class RectangleWaveform extends AudioWaveform {
   /// The color of the inactive waveform border.
   final Color inactiveBorderColor;
 
+  final bool isRoundedRectangle;
+
   @override
   AudioWaveformState<RectangleWaveform> createState() =>
       _RectangleWaveformState();
@@ -106,6 +109,7 @@ class _RectangleWaveformState extends AudioWaveformState<RectangleWaveform> {
               borderColor: widget.inactiveBorderColor,
               borderWidth: widget.borderWidth,
               sampleWidth: sampleWidth,
+              isRoundedRectangle: widget.isRoundedRectangle,
             ),
           ),
         ),
@@ -122,6 +126,7 @@ class _RectangleWaveformState extends AudioWaveformState<RectangleWaveform> {
                 borderColor: widget.activeBorderColor,
                 borderWidth: widget.borderWidth,
                 sampleWidth: sampleWidth,
+                isRoundedRectangle: widget.isRoundedRectangle,
               ),
             ),
           ),

--- a/lib/src/waveforms/rectangle_waveform/rectangle_waveform.dart
+++ b/lib/src/waveforms/rectangle_waveform/rectangle_waveform.dart
@@ -39,6 +39,7 @@ class RectangleWaveform extends AudioWaveform {
     bool absolute = false,
     bool invert = false,
     this.isRoundedRectangle = false,
+    this.isCentered = false,
   })  : assert(
           borderWidth >= 0 && borderWidth <= 1.0,
           'BorderWidth must be between 0 and 1',
@@ -79,6 +80,9 @@ class RectangleWaveform extends AudioWaveform {
   /// If true then rounded rectangles are drawn instead of regular rectangles.
   final bool isRoundedRectangle;
 
+  /// If true then rounded rectangles are drawn instead of regular rectangles.
+  final bool isCentered;
+
   @override
   AudioWaveformState<RectangleWaveform> createState() =>
       _RectangleWaveformState();
@@ -96,40 +100,45 @@ class _RectangleWaveformState extends AudioWaveformState<RectangleWaveform> {
     final waveformAlignment = this.waveformAlignment;
     final sampleWidth = this.sampleWidth;
 
-    return Stack(
-      children: [
-        RepaintBoundary(
-          child: CustomPaint(
-            size: Size(widget.width, widget.height),
-            isComplex: true,
-            painter: RectangleInActiveWaveformPainter(
-              samples: processedSamples,
-              color: widget.inactiveColor,
-              gradient: widget.inactiveGradient,
-              waveformAlignment: waveformAlignment,
-              borderColor: widget.inactiveBorderColor,
-              borderWidth: widget.borderWidth,
-              sampleWidth: sampleWidth,
-              isRoundedRectangle: widget.isRoundedRectangle,
+    return Container(
+      color: Colors.white38,
+      child: Stack(
+        children: [
+          RepaintBoundary(
+            child: CustomPaint(
+              size: Size(widget.width, widget.height),
+              isComplex: true,
+              painter: RectangleInActiveWaveformPainter(
+                samples: processedSamples,
+                color: widget.inactiveColor,
+                gradient: widget.inactiveGradient,
+                waveformAlignment: waveformAlignment,
+                borderColor: widget.inactiveBorderColor,
+                borderWidth: widget.borderWidth,
+                sampleWidth: sampleWidth,
+                isRoundedRectangle: widget.isRoundedRectangle,
+                isCentered: widget.isCentered,
+              ),
             ),
           ),
-        ),
-        if (showActiveWaveform)
-          CustomPaint(
-            size: Size(widget.width, widget.height),
-            isComplex: true,
-            painter: RectangleActiveWaveformPainter(
-              color: widget.activeColor,
-              activeSamples: activeSamples,
-              gradient: widget.activeGradient,
-              waveformAlignment: waveformAlignment,
-              borderColor: widget.activeBorderColor,
-              borderWidth: widget.borderWidth,
-              sampleWidth: sampleWidth,
-              isRoundedRectangle: widget.isRoundedRectangle,
+          if (showActiveWaveform)
+            CustomPaint(
+              size: Size(widget.width, widget.height),
+              isComplex: true,
+              painter: RectangleActiveWaveformPainter(
+                color: widget.activeColor,
+                activeSamples: activeSamples,
+                gradient: widget.activeGradient,
+                waveformAlignment: waveformAlignment,
+                borderColor: widget.activeBorderColor,
+                borderWidth: widget.borderWidth,
+                sampleWidth: sampleWidth,
+                isRoundedRectangle: widget.isRoundedRectangle,
+                isCentered: widget.isCentered,
+              ),
             ),
-          ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/lib/src/waveforms/squiggly_waveform/squiggly_waveform.dart
+++ b/lib/src/waveforms/squiggly_waveform/squiggly_waveform.dart
@@ -96,21 +96,19 @@ class _SquigglyWaveformState extends AudioWaveformState<SquigglyWaveform> {
     final activeRatio = this.activeRatio;
     final waveformAlignment = this.waveformAlignment;
 
-    return RepaintBoundary(
-      child: CustomPaint(
-        size: Size(widget.width, widget.height),
-        isComplex: true,
-        painter: SquigglyWaveformPainter(
-          samples: processedSamples,
-          activeColor: widget.activeColor,
-          inactiveColor: widget.inactiveColor,
-          activeRatio: activeRatio,
-          waveformAlignment: waveformAlignment,
-          absolute: widget.absolute,
-          invert: widget.invert,
-          strokeWidth: widget.strokeWidth,
-          sampleWidth: sampleWidth,
-        ),
+    return CustomPaint(
+      size: Size(widget.width, widget.height),
+      isComplex: true,
+      painter: SquigglyWaveformPainter(
+        samples: processedSamples,
+        activeColor: widget.activeColor,
+        inactiveColor: widget.inactiveColor,
+        activeRatio: activeRatio,
+        waveformAlignment: waveformAlignment,
+        absolute: widget.absolute,
+        invert: widget.invert,
+        strokeWidth: widget.strokeWidth,
+        sampleWidth: sampleWidth,
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_audio_waveforms
 description: A UI library for easily adding audio waveforms to your apps, with several customization options.
-version: 1.1.1+4
+version: 1.2.1+4
 homepage: https://github.com/rutvik110/flutter_audio_waveforms
 
 environment:


### PR DESCRIPTION
### Updates : 

**Rectangle Waveform :** 

Two new customization options called `isRoundedRectangle`[bool] and `isCentered`[bool] added to RectangleWaveform Api.

`isRoundedRectangle` : If true then rounded rectangles are drawn instead of regular rectangles.
  final bool isRoundedRectangle;

`isCentered` : If true then rectangles are centered along the Y-axis with respect to their center along their height. If [absolute] is true then this would've no effect.

**Removed redundant RepaintBoundary wrapper** :
 Removed redundant RepaintBoundary wrapper around active waveforms and activeinactive waveform CustomPainters. This was done to avoid increase in memory usage as RepaintBoundary would catch the subtree. In case of active/inactivewaveforms, the subtree is changing constantly so the caching was done every frame thus increasing memory usage.

**`shouldRepaint `logic in abstract CustomPainter classes:**

Extracted `shouldRepaint` logic into its separate method to calculate whether to repaint or not. Advantage being, this method in abstract classes can be used within subclasses which may have more arguments that change but doesn't pass those to abstract class and can be used directly without duplicating code for shouldRepaint logic of abstract class.

