### PR TITLE
fix(rectangle_waveform): active waveform painter not rounding the same as the inactive painter

### DIFF
--- a/lib/src/waveforms/rectangle_waveform/active_waveform_painter.dart
+++ b/lib/src/waveforms/rectangle_waveform/active_waveform_painter.dart
@@ -100,6 +100,7 @@ class RectangleActiveWaveformPainter extends ActiveWaveformPainter {
     WaveformAlignment waveformAlignment,
     bool isCentered,
   ) {
+    final radius = Radius.circular(sampleWidth);
     for (var i = 0; i < activeSamples.length; i++) {
       if (i.isEven) {
         final x = sampleWidth * i;
@@ -114,21 +115,22 @@ class RectangleActiveWaveformPainter extends ActiveWaveformPainter {
             : !isCentered
                 ? alignPosition
                 : alignPosition - y / 2;
+        final rectangle = Rect.fromLTWH(x, positionFromTop, sampleWidth, y);
 
         //Draws the filled rectangles of the waveform.
         canvas
           ..drawRRect(
             RRect.fromRectAndRadius(
-              Rect.fromLTWH(x, positionFromTop, sampleWidth, y),
-              Radius.circular(x),
+              rectangle,
+              radius,
             ),
             paint,
           )
           //Draws the border for the rectangles of the waveform.
           ..drawRRect(
             RRect.fromRectAndRadius(
-              Rect.fromLTWH(x, positionFromTop, sampleWidth, y),
-              Radius.circular(x),
+              rectangle,
+              radius,
             ),
             borderPaint,
           );


### PR DESCRIPTION
This would cause the first and last rectangle to not be rounded.

Before:
![Screenshot 2024-02-08 at 3 17 49 PM](https://github.com/rutvik110/flutter_audio_waveforms/assets/13773566/04f6c0f7-ce80-4c9a-9783-b5afe3543843)

After:
<img width="79" alt="Screenshot 2024-02-08 at 3 15 23 PM" src="https://github.com/rutvik110/flutter_audio_waveforms/assets/13773566/9cefccb4-e02f-49ce-8a29-6ee299f6de68">
